### PR TITLE
Add email capture form and backend handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,12 @@ app.use(express.static(__dirname + '/public'));
 app.get('/', function(req, res) {
         res.sendfile(__dirname + '/public/index.html');
     });
+
+app.get('/subscribe', function(req, res){
+        var email = req.query.email;
+        console.log('Email submitted:', email);
+        res.status(200).send('Email received');
+});
     
 // Create the MQTT server    
 var mqttServe = new mosca.Server({});

--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,16 @@
 	</div>
 	<br>
     <div class="container">
-    	<h1>Blue Messenger</h1>
+        <h1>Blue Messenger</h1>
+        <br/>
+
+        <form id="email-form" action="/subscribe" method="GET">
+            <div class="form-group">
+                <label for="email">Email address:</label>
+                <input type="email" class="form-control" id="email" name="email" placeholder="Enter your email" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Subscribe</button>
+        </form>
         <br/>
         
         <div class="col-xs-2">

--- a/public/scripts/script.js
+++ b/public/scripts/script.js
@@ -9,6 +9,15 @@ $(document).ready(function(){
     var duration;
     var spamControl;
     var messageCount = 0;
+
+    $('#email-form').on('submit', function(e){
+        e.preventDefault();
+        var email = $('#email').val();
+        $.get($(this).attr('action'), { email: email })
+            .done(function(){
+                console.log('Email submitted:', email);
+            });
+    });
 	
 	//functions to configure buttons
     //the send button also acts as a connection signal


### PR DESCRIPTION
## Summary
- add email subscription form with GET action to `/subscribe`
- intercept form submission client-side and send email to backend
- log submitted email on server via new `/subscribe` endpoint

## Testing
- `npm test` (fails: Missing script)
- `node app.js` (fails: SchemaError: Expected `schema` to be an object or boolean)


------
https://chatgpt.com/codex/tasks/task_e_689929211a608324b581825491762678